### PR TITLE
Update elasticsearch-close-old-indices.sh

### DIFF
--- a/elasticsearch-close-old-indices.sh
+++ b/elasticsearch-close-old-indices.sh
@@ -116,8 +116,10 @@ if [ ${#INDEX[@]} -gt $KEEP ]; then
       if [ -z "$LOGFILE" ]; then
         curl -s -XPOST "$ELASTICSEARCH/$index/_close" > /dev/null
       else
-        echo `date "+[%Y-%m-%d %H:%M] "`" Closing index: $index." >> $LOGFILE
+        echo -n `date "+[%Y-%m-%d %H:%M] "`" Closing index: $index." >> $LOGFILE
+        curl -s -XPOST "$ELASTICSEARCH/$index/_flush" >> $LOGFILE
         curl -s -XPOST "$ELASTICSEARCH/$index/_close" >> $LOGFILE
+        echo "." >> $LOGFILE
       fi
     fi
   done


### PR DESCRIPTION
Flushing the index before closing. Also make the log output easier to read and understand (single close operation create single log line)